### PR TITLE
MER-113 - Migrate back to react-native-brother-printer

### DIFF
--- a/index.js
+++ b/index.js
@@ -155,6 +155,17 @@ export const discoverBluetoothPrinters = async () => {
   }
 };
 
+export const discoverBLEPrinters = async () => {
+  try {
+    const printers = await ReactNativeBrotherPrinters.discoverBLEPrinters();
+    console.log('Discovered printers:', printers);
+    return printers;
+  } catch (error) {
+    console.error('Error discovering printers:', error);
+    throw error;
+  }
+};
+
 export const connectToBluetoothPrinter = async (serialNumber) => {
   try {
     const result = await ReactNativeBrotherPrinters.connectToBluetoothPrinter(serialNumber);

--- a/ios/ReactNativeBrotherPrinters.m
+++ b/ios/ReactNativeBrotherPrinters.m
@@ -161,65 +161,26 @@ RCT_REMAP_METHOD(printImage, deviceInfo:(NSDictionary *)device printerUri: (NSSt
     }
 }
 
-// RCT_EXPORT_METHOD(discoverBluetoothPrinters:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
-//   BRPtouchBluetoothManager *bluetoothManager = [BRPtouchBluetoothManager sharedManager];
-//   NSArray *pairedPrinters = [bluetoothManager pairedDevices];
-  
-//   NSMutableArray *printers = [NSMutableArray array];
-//   for (BRPtouchDeviceInfo *deviceInfo in pairedPrinters) {
-//     [printers addObject:@{
-//       @"printerName": deviceInfo.strPrinterName,
-//       @"modelName": deviceInfo.strModelName,
-//       @"serialNumber": deviceInfo.strSerialNumber
-//     }];
-//   }
-  
-//   resolve(printers);
-// }
+RCT_EXPORT_METHOD(discoverBluetoothPrinters:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+  BRLMPrinterSearcher *printerSearcher = [[BRLMPrinterSearcher alloc] init];
+  BRLMPrinterSearcherResult *searchResult = [printerSearcher searchPrintersWithInterface:BRLMChannelTypeBluetooth];
 
-// RCT_EXPORT_METHOD(connectToBluetoothPrinter:(NSString *)serialNumber resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
-//   BRPtouchBluetoothManager *bluetoothManager = [BRPtouchBluetoothManager sharedManager];
-//   NSArray *pairedPrinters = [bluetoothManager pairedDevices];
-  
-//   for (BRPtouchDeviceInfo *deviceInfo in pairedPrinters) {
-//     if ([deviceInfo.strSerialNumber isEqualToString:serialNumber]) {
-//       // Create a BRLMPrinterDriver for the selected printer
-//       BRLMPrinterDriver *printerDriver = [[BRLMPrinterDriver alloc] initWithDeviceInfo:deviceInfo];
-//       if (printerDriver) {
-//         resolve(@{@"status": @"connected", @"printerName": deviceInfo.strPrinterName});
-//         return;
-//       }
-//     }
-//   }
-  
-//   reject(@"not_found", @"Printer not found", nil);
-// }
+  if (searchResult.error.code != BRLMPrinterSearcherErrorCodeNoError) {
+    reject(DISCOVER_READERS_ERROR, @"Failed to discover Bluetooth printers", nil);
+    return;
+  }
 
-// RCT_EXPORT_METHOD(printViaBluetooth:(NSString *)serialNumber data:(NSString *)data resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
-//   BRPtouchBluetoothManager *bluetoothManager = [BRPtouchBluetoothManager sharedManager];
-//   NSArray *pairedPrinters = [bluetoothManager pairedDevices];
-  
-//   for (BRPtouchDeviceInfo *deviceInfo in pairedPrinters) {
-//     if ([deviceInfo.strSerialNumber isEqualToString:serialNumber]) {
-//       BRLMPrinterDriver *printerDriver = [[BRLMPrinterDriver alloc] initWithDeviceInfo:deviceInfo];
-//       if (printerDriver) {
-//         // Convert data to NSData and send to printer
-//         NSData *printData = [data dataUsingEncoding:NSUTF8StringEncoding];
-//         NSError *error = nil;
-//         [printerDriver sendData:printData error:&error];
-        
-//         if (error) {
-//           reject(@"print_error", @"Failed to print", error);
-//         } else {
-//           resolve(@{@"status": @"printed"});
-//         }
-//         return;
-//       }
-//     }
-//   }
-  
-//   reject(@"not_found", @"Printer not found", nil);
-// }
+  NSMutableArray *printers = [NSMutableArray array];
+  for (BRLMPrinterSearchResult *result in searchResult.printerSearchResults) {
+    [printers addObject:@{
+      @"printerName": result.printerName,
+      @"modelName": result.modelName,
+      @"serialNumber": result.serialNumber
+    }];
+  }
+
+  resolve(printers);
+}
 
 -(void)didFinishSearch:(id)sender
 {

--- a/ios/ReactNativeBrotherPrinters.m
+++ b/ios/ReactNativeBrotherPrinters.m
@@ -88,14 +88,12 @@ RCT_REMAP_METHOD(printImage, deviceInfo:(NSDictionary *)device printerUri: (NSSt
     BRPtouchDeviceInfo *deviceInfo = [self deserializeDeviceInfo:device];
 
     BRLMChannel *channel = [[BRLMChannel alloc] initWithWifiIPAddress:deviceInfo.strIPAddress];
-
     BRLMPrinterDriverGenerateResult *driverGenerateResult = [BRLMPrinterDriverGenerator openChannel:channel];
-    if (driverGenerateResult.error.code != BRLMOpenChannelErrorCodeNoError ||
-        driverGenerateResult.driver == nil) {
-        NSLog(@"%@", @(driverGenerateResult.error.code));
+    if (driverGenerateResult.error.code != BRLMOpenChannelErrorCodeNoError || driverGenerateResult.driver == nil) {
+        NSLog(@"Error initializing printer driver: %@", @(driverGenerateResult.error.code));
+        reject(@"driver_init_error", @"Failed to initialize printer driver", nil);
         return;
     }
-
     BRLMPrinterDriver *printerDriver = driverGenerateResult.driver;
 
     BRLMPrinterModel model = [BRLMPrinterClassifier transferEnumFromString:deviceInfo.strModelName];

--- a/ios/ReactNativeBrotherPrinters.m
+++ b/ios/ReactNativeBrotherPrinters.m
@@ -163,65 +163,65 @@ RCT_REMAP_METHOD(printImage, deviceInfo:(NSDictionary *)device printerUri: (NSSt
     }
 }
 
-RCT_EXPORT_METHOD(discoverBluetoothPrinters:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
-  BRPtouchBluetoothManager *bluetoothManager = [BRPtouchBluetoothManager sharedManager];
-  NSArray *pairedPrinters = [bluetoothManager pairedDevices];
+// RCT_EXPORT_METHOD(discoverBluetoothPrinters:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+//   BRPtouchBluetoothManager *bluetoothManager = [BRPtouchBluetoothManager sharedManager];
+//   NSArray *pairedPrinters = [bluetoothManager pairedDevices];
   
-  NSMutableArray *printers = [NSMutableArray array];
-  for (BRPtouchDeviceInfo *deviceInfo in pairedPrinters) {
-    [printers addObject:@{
-      @"printerName": deviceInfo.strPrinterName,
-      @"modelName": deviceInfo.strModelName,
-      @"serialNumber": deviceInfo.strSerialNumber
-    }];
-  }
+//   NSMutableArray *printers = [NSMutableArray array];
+//   for (BRPtouchDeviceInfo *deviceInfo in pairedPrinters) {
+//     [printers addObject:@{
+//       @"printerName": deviceInfo.strPrinterName,
+//       @"modelName": deviceInfo.strModelName,
+//       @"serialNumber": deviceInfo.strSerialNumber
+//     }];
+//   }
   
-  resolve(printers);
-}
+//   resolve(printers);
+// }
 
-RCT_EXPORT_METHOD(connectToBluetoothPrinter:(NSString *)serialNumber resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
-  BRPtouchBluetoothManager *bluetoothManager = [BRPtouchBluetoothManager sharedManager];
-  NSArray *pairedPrinters = [bluetoothManager pairedDevices];
+// RCT_EXPORT_METHOD(connectToBluetoothPrinter:(NSString *)serialNumber resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+//   BRPtouchBluetoothManager *bluetoothManager = [BRPtouchBluetoothManager sharedManager];
+//   NSArray *pairedPrinters = [bluetoothManager pairedDevices];
   
-  for (BRPtouchDeviceInfo *deviceInfo in pairedPrinters) {
-    if ([deviceInfo.strSerialNumber isEqualToString:serialNumber]) {
-      // Create a BRLMPrinterDriver for the selected printer
-      BRLMPrinterDriver *printerDriver = [[BRLMPrinterDriver alloc] initWithDeviceInfo:deviceInfo];
-      if (printerDriver) {
-        resolve(@{@"status": @"connected", @"printerName": deviceInfo.strPrinterName});
-        return;
-      }
-    }
-  }
+//   for (BRPtouchDeviceInfo *deviceInfo in pairedPrinters) {
+//     if ([deviceInfo.strSerialNumber isEqualToString:serialNumber]) {
+//       // Create a BRLMPrinterDriver for the selected printer
+//       BRLMPrinterDriver *printerDriver = [[BRLMPrinterDriver alloc] initWithDeviceInfo:deviceInfo];
+//       if (printerDriver) {
+//         resolve(@{@"status": @"connected", @"printerName": deviceInfo.strPrinterName});
+//         return;
+//       }
+//     }
+//   }
   
-  reject(@"not_found", @"Printer not found", nil);
-}
+//   reject(@"not_found", @"Printer not found", nil);
+// }
 
-RCT_EXPORT_METHOD(printViaBluetooth:(NSString *)serialNumber data:(NSString *)data resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
-  BRPtouchBluetoothManager *bluetoothManager = [BRPtouchBluetoothManager sharedManager];
-  NSArray *pairedPrinters = [bluetoothManager pairedDevices];
+// RCT_EXPORT_METHOD(printViaBluetooth:(NSString *)serialNumber data:(NSString *)data resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+//   BRPtouchBluetoothManager *bluetoothManager = [BRPtouchBluetoothManager sharedManager];
+//   NSArray *pairedPrinters = [bluetoothManager pairedDevices];
   
-  for (BRPtouchDeviceInfo *deviceInfo in pairedPrinters) {
-    if ([deviceInfo.strSerialNumber isEqualToString:serialNumber]) {
-      BRLMPrinterDriver *printerDriver = [[BRLMPrinterDriver alloc] initWithDeviceInfo:deviceInfo];
-      if (printerDriver) {
-        // Convert data to NSData and send to printer
-        NSData *printData = [data dataUsingEncoding:NSUTF8StringEncoding];
-        NSError *error = nil;
-        [printerDriver sendData:printData error:&error];
+//   for (BRPtouchDeviceInfo *deviceInfo in pairedPrinters) {
+//     if ([deviceInfo.strSerialNumber isEqualToString:serialNumber]) {
+//       BRLMPrinterDriver *printerDriver = [[BRLMPrinterDriver alloc] initWithDeviceInfo:deviceInfo];
+//       if (printerDriver) {
+//         // Convert data to NSData and send to printer
+//         NSData *printData = [data dataUsingEncoding:NSUTF8StringEncoding];
+//         NSError *error = nil;
+//         [printerDriver sendData:printData error:&error];
         
-        if (error) {
-          reject(@"print_error", @"Failed to print", error);
-        } else {
-          resolve(@{@"status": @"printed"});
-        }
-        return;
-      }
-    }
-  }
+//         if (error) {
+//           reject(@"print_error", @"Failed to print", error);
+//         } else {
+//           resolve(@{@"status": @"printed"});
+//         }
+//         return;
+//       }
+//     }
+//   }
   
-  reject(@"not_found", @"Printer not found", nil);
-}
+//   reject(@"not_found", @"Printer not found", nil);
+// }
 
 -(void)didFinishSearch:(id)sender
 {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/W3lcomeApp/react-native-brother-printers.git",
-    "baseUrl": "https://github.com/W3lcomeApp/react-native-brother-printers"
+    "url": "git+https://github.com/blanton-cloud/react-native-brother-printers.git",
+    "baseUrl": "https://github.com/blanton-cloud/react-native-brother-printers"
   },
   "keywords": [
     "react-native",
@@ -31,7 +31,8 @@
     "email": "avery@dripos.com"
   },
   "contributors": [
-    "Alisson Enz Rossi <alisson@w3lcome.com>"
+    "Alisson Enz Rossi <alisson@w3lcome.com>",
+    "Michael Blanton <michael@blanton.cloud>"
   ],
   "license": "MIT",
   "readmeFilename": "README.md",

--- a/react-native-brother-printers.podspec
+++ b/react-native-brother-printers.podspec
@@ -15,13 +15,13 @@ Pod::Spec.new do |s|
   s.license      = "MIT"
   s.authors      = { "W3lcome" => "dev@w3lcome.com" }
   s.platforms    = { :ios => "13.0" }
-  s.source       = { :git => "https://github.com/W3lcomeApp/react-native-brother-printers.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/W3lcomeApp/react-native-brother-printers.git", :tag => "v#{s.version}" }
 
   s.source_files = "ios/**/*.{h,c,cc,cpp,m,mm,swift,plist}"
   s.requires_arc = true
   s.resources = 'ios/**/*.plist'
 
   s.dependency "React"
-  s.dependency "BRLMPrinterKit"
+  s.dependency "BRLMPrinterKit", :git => "https://github.com/your-username/BRLMPrinterKit.git", :tag => "v4.12.0"
 end
 

--- a/react-native-brother-printers.podspec
+++ b/react-native-brother-printers.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/W3lcomeApp/react-native-brother-printers"
   s.license      = "MIT"
   s.authors      = { "W3lcome" => "dev@w3lcome.com" }
-  s.platforms    = { :ios => "9.0" }
+  s.platforms    = { :ios => "13.0" }
   s.source       = { :git => "https://github.com/W3lcomeApp/react-native-brother-printers.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,c,cc,cpp,m,mm,swift,plist}"
@@ -22,6 +22,6 @@ Pod::Spec.new do |s|
   s.resources = 'ios/**/*.plist'
 
   s.dependency "React"
-  s.dependency "BRLMPrinterKit", '4.7.2'
+  s.dependency "BRLMPrinterKit", { :git => "https://github.com/blanton-cloud/BRLMPrinterKit.git", :tag => "4.12.0"}
 end
 

--- a/react-native-brother-printers.podspec
+++ b/react-native-brother-printers.podspec
@@ -22,6 +22,6 @@ Pod::Spec.new do |s|
   s.resources = 'ios/**/*.plist'
 
   s.dependency "React"
-  s.dependency "BRLMPrinterKit", { :git => "https://github.com/blanton-cloud/BRLMPrinterKit.git", :tag => "4.12.0"}
+  s.dependency "BRLMPrinterKit"
 end
 


### PR DESCRIPTION
This pull request includes several updates and improvements to the `react-native-brother-printers` package. The changes primarily focus on enhancing Bluetooth and BLE printer discovery, improving error handling, and updating dependencies and metadata.

### Printer Discovery and Connection Enhancements:

* Added a new method `discoverBLEPrinters` to discover BLE printers using `ReactNativeBrotherPrinters.discoverBLEPrinters()` and log the discovered printers. (`index.js`)
* Updated the `printImage` method to support both Bluetooth and WiFi connections based on the provided device type and connection details. (`ios/ReactNativeBrotherPrinters.m`)
* Simplified the logic for setting print quality and halftone options in the `printImage` method. (`ios/ReactNativeBrotherPrinters.m`)

### Error Handling Improvements:

* Enhanced error handling in the `printImage` method by providing more detailed error messages and closing the printer channel upon failure. (`ios/ReactNativeBrotherPrinters.m`)

### Metadata and Dependency Updates:

* Updated the repository URL and added a new contributor in `package.json`. (`package.json`) [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L20-R21) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L34-R35)
* Increased the minimum iOS platform version to 13.0 and removed the specific version dependency for `BRLMPrinterKit` in the podspec file. (`react-native-brother-printers.podspec`)