### PR TITLE
Michael/mer 113 migrate back to react native brother printer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 #
 node_modules/
 npm-debug.log
-yarn-error.log
+-error.log
 
 # Xcode
 #
@@ -52,4 +52,25 @@ buck-out/
 Pods/
 
 # End of https://www.toptal.com/developers/gitignore/api/cocoapods
+n# Created by https://www.toptal.com/developers/gitignore/api/yarn
+# Edit at https://www.toptal.com/developers/gitignore?templates=yarn
+
+### yarn ###
+# https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored
+
+.yarn/*
+!.yarn/releases
+!.yarn/patches
+!.yarn/plugins
+!.yarn/sdks
+!.yarn/versions
+
+# if you are NOT using Zero-installs, then:
+# comment the following lines
+!.yarn/cache
+
+# and uncomment the following lines
+# .pnp.*
+
+# End of https://www.toptal.com/developers/gitignore/api/yarn
 n

--- a/index.js
+++ b/index.js
@@ -196,3 +196,21 @@ if (ReactNativeBrotherPrinters) {
 export function registerBrotherListener(key, method) {
   return listeners?.addListener(key, method);
 }
+
+/**
+ * Retrieves the status of a printer
+ *
+ * @param device                  Device object
+ * @param device.type             Type of the device (e.g., "bluetooth" or "wifi")
+ * @param device.serialNumber     Serial number of the device (required for Bluetooth)
+ * @param device.ipAddress        IP address of the device (required for WiFi)
+ *
+ * @return {Promise<Object>}      Printer status object
+ */
+export async function getPrinterStatus(device) {
+  if (!device || !device.type) {
+    throw new Error("Device type must be specified");
+  }
+
+  return ReactNativeBrotherPrinters?.getPrinterStatus(device);
+}

--- a/index.js
+++ b/index.js
@@ -4,65 +4,75 @@ import { NativeModules, NativeEventEmitter } from "react-native";
 
 const { ReactNativeBrotherPrinters } = NativeModules || {};
 
-export const LabelSizeDieCutW17H54 = 0;
-export const LabelSizeDieCutW17H87 = 1;
-export const LabelSizeDieCutW23H23 = 2;
-export const LabelSizeDieCutW29H42 = 3;
-export const LabelSizeDieCutW29H90 = 4;
-export const LabelSizeDieCutW38H90 = 5;
-export const LabelSizeDieCutW39H48 = 6;
-export const LabelSizeDieCutW52H29 = 7;
-export const LabelSizeDieCutW62H29 = 8;
-export const LabelSizeDieCutW62H100 = 9;
-export const LabelSizeDieCutW60H86 = 10;
-export const LabelSizeDieCutW54H29 = 11;
-export const LabelSizeDieCutW102H51 = 12;
-export const LabelSizeDieCutW102H152 = 13;
-export const LabelSizeDieCutW103H164 = 14;
-export const LabelSizeRollW12 = 15;
-export const LabelSizeRollW29 = 16;
-export const LabelSizeRollW38 = 17;
-export const LabelSizeRollW50 = 18;
-export const LabelSizeRollW54 = 19;
-export const LabelSizeRollW62 = 20;
-export const LabelSizeRollW62RB = 21;
-export const LabelSizeRollW102 = 22;
-export const LabelSizeRollW103 = 23;
-export const LabelSizeDTRollW90 = 24;
-export const LabelSizeDTRollW102 = 25;
-export const LabelSizeDTRollW102H51 = 26;
-export const LabelSizeDTRollW102H152 = 27;
+export const BRLMQLPrintSettingsLabelSizeDieCutW17H54 = 0;
+export const BRLMQLPrintSettingsLabelSizeDieCutW17H87 = 1;
+export const BRLMQLPrintSettingsLabelSizeDieCutW23H23 = 2;
+export const BRLMQLPrintSettingsLabelSizeDieCutW29H42 = 3;
+export const BRLMQLPrintSettingsLabelSizeDieCutW29H90 = 4;
+export const BRLMQLPrintSettingsLabelSizeDieCutW38H90 = 5;
+export const BRLMQLPrintSettingsLabelSizeDieCutW39H48 = 6;
+export const BRLMQLPrintSettingsLabelSizeDieCutW52H29 = 7;
+export const BRLMQLPrintSettingsLabelSizeDieCutW62H29 = 8;
+export const BRLMQLPrintSettingsLabelSizeDieCutW62H60 = 9;
+export const BRLMQLPrintSettingsLabelSizeDieCutW62H75 = 10;
+export const BRLMQLPrintSettingsLabelSizeDieCutW62H100 = 11;
+export const BRLMQLPrintSettingsLabelSizeDieCutW60H86 = 12;
+export const BRLMQLPrintSettingsLabelSizeDieCutW54H29 = 13;
+export const BRLMQLPrintSettingsLabelSizeDieCutW102H51 = 14;
+export const BRLMQLPrintSettingsLabelSizeDieCutW102H152 = 15;
+export const BRLMQLPrintSettingsLabelSizeDieCutW103H164 = 16;
+export const BRLMQLPrintSettingsLabelSizeRollW12 = 17;
+export const BRLMQLPrintSettingsLabelSizeRollW29 = 18;
+export const BRLMQLPrintSettingsLabelSizeRollW38 = 19;
+export const BRLMQLPrintSettingsLabelSizeRollW50 = 20;
+export const BRLMQLPrintSettingsLabelSizeRollW54 = 21;
+export const BRLMQLPrintSettingsLabelSizeRollW62 = 22;
+export const BRLMQLPrintSettingsLabelSizeRollW62RB = 23;
+export const BRLMQLPrintSettingsLabelSizeRollW102 = 24;
+export const BRLMQLPrintSettingsLabelSizeRollW103 = 25;
+export const BRLMQLPrintSettingsLabelSizeDTRollW90 = 26;
+export const BRLMQLPrintSettingsLabelSizeDTRollW102 = 27;
+export const BRLMQLPrintSettingsLabelSizeDTRollW102H51 = 28;
+export const BRLMQLPrintSettingsLabelSizeDTRollW102H152 = 29;
+export const BRLMQLPrintSettingsLabelSizeRoundW12DIA = 30;
+export const BRLMQLPrintSettingsLabelSizeRoundW24DIA = 31;
+export const BRLMQLPrintSettingsLabelSizeRoundW58DIA = 32;
 
 export const LabelSize = {
-  LabelSizeDieCutW17H54,
-  LabelSizeDieCutW17H87,
-  LabelSizeDieCutW23H23,
-  LabelSizeDieCutW29H42,
-  LabelSizeDieCutW29H90,
-  LabelSizeDieCutW38H90,
-  LabelSizeDieCutW39H48,
-  LabelSizeDieCutW52H29,
-  LabelSizeDieCutW62H29,
-  LabelSizeDieCutW62H100,
-  LabelSizeDieCutW60H86,
-  LabelSizeDieCutW54H29,
-  LabelSizeDieCutW102H51,
-  LabelSizeDieCutW102H152,
-  LabelSizeDieCutW103H164,
-  LabelSizeRollW12,
-  LabelSizeRollW29,
-  LabelSizeRollW38,
-  LabelSizeRollW50,
-  LabelSizeRollW54,
-  LabelSizeRollW62,
-  LabelSizeRollW62RB,
-  LabelSizeRollW102,
-  LabelSizeRollW103,
-  LabelSizeDTRollW90,
-  LabelSizeDTRollW102,
-  LabelSizeDTRollW102H51,
-  LabelSizeDTRollW102H152,
-}
+  BRLMQLPrintSettingsLabelSizeDieCutW17H54,
+  BRLMQLPrintSettingsLabelSizeDieCutW17H87,
+  BRLMQLPrintSettingsLabelSizeDieCutW23H23,
+  BRLMQLPrintSettingsLabelSizeDieCutW29H42,
+  BRLMQLPrintSettingsLabelSizeDieCutW29H90,
+  BRLMQLPrintSettingsLabelSizeDieCutW38H90,
+  BRLMQLPrintSettingsLabelSizeDieCutW39H48,
+  BRLMQLPrintSettingsLabelSizeDieCutW52H29,
+  BRLMQLPrintSettingsLabelSizeDieCutW62H29,
+  BRLMQLPrintSettingsLabelSizeDieCutW62H60,
+  BRLMQLPrintSettingsLabelSizeDieCutW62H75,
+  BRLMQLPrintSettingsLabelSizeDieCutW62H100,
+  BRLMQLPrintSettingsLabelSizeDieCutW60H86,
+  BRLMQLPrintSettingsLabelSizeDieCutW54H29,
+  BRLMQLPrintSettingsLabelSizeDieCutW102H51,
+  BRLMQLPrintSettingsLabelSizeDieCutW102H152,
+  BRLMQLPrintSettingsLabelSizeDieCutW103H164,
+  BRLMQLPrintSettingsLabelSizeRollW12,
+  BRLMQLPrintSettingsLabelSizeRollW29,
+  BRLMQLPrintSettingsLabelSizeRollW38,
+  BRLMQLPrintSettingsLabelSizeRollW50,
+  BRLMQLPrintSettingsLabelSizeRollW54,
+  BRLMQLPrintSettingsLabelSizeRollW62,
+  BRLMQLPrintSettingsLabelSizeRollW62RB,
+  BRLMQLPrintSettingsLabelSizeRollW102,
+  BRLMQLPrintSettingsLabelSizeRollW103,
+  BRLMQLPrintSettingsLabelSizeDTRollW90,
+  BRLMQLPrintSettingsLabelSizeDTRollW102,
+  BRLMQLPrintSettingsLabelSizeDTRollW102H51,
+  BRLMQLPrintSettingsLabelSizeDTRollW102H152,
+  BRLMQLPrintSettingsLabelSizeRoundW12DIA,
+  BRLMQLPrintSettingsLabelSizeRoundW24DIA,
+  BRLMQLPrintSettingsLabelSizeRoundW58DIA,
+};
 
 export const LabelNames = [
   "Die Cut 17mm x 54mm", // 0

--- a/ios/ReactNativeBrotherPrinters.xcodeproj/project.pbxproj
+++ b/ios/ReactNativeBrotherPrinters.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		7C011CA2970839D47FC1D8B3 /* Pods_ReactNativeBrotherPrinters.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 49DBED8AC320EBCF00FA637F /* Pods_ReactNativeBrotherPrinters.framework */; };
+		18E633BD32B7E837F2ABDEEB /* Pods_ReactNativeBrotherPrinters.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 54055F345F8BEC9FC56F1799 /* Pods_ReactNativeBrotherPrinters.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -24,9 +24,9 @@
 
 /* Begin PBXFileReference section */
 		134814201AA4EA6300B7C361 /* libReactNativeBrotherPrinters.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libReactNativeBrotherPrinters.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		49DBED8AC320EBCF00FA637F /* Pods_ReactNativeBrotherPrinters.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ReactNativeBrotherPrinters.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		B075CBD3033F9D0F095C16E7 /* Pods-ReactNativeBrotherPrinters.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReactNativeBrotherPrinters.release.xcconfig"; path = "Target Support Files/Pods-ReactNativeBrotherPrinters/Pods-ReactNativeBrotherPrinters.release.xcconfig"; sourceTree = "<group>"; };
-		BF810F2AE8820ECD15B335EC /* Pods-ReactNativeBrotherPrinters.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReactNativeBrotherPrinters.debug.xcconfig"; path = "Target Support Files/Pods-ReactNativeBrotherPrinters/Pods-ReactNativeBrotherPrinters.debug.xcconfig"; sourceTree = "<group>"; };
+		427543E9A8C65547AA1B6897 /* Pods-ReactNativeBrotherPrinters.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReactNativeBrotherPrinters.release.xcconfig"; path = "Target Support Files/Pods-ReactNativeBrotherPrinters/Pods-ReactNativeBrotherPrinters.release.xcconfig"; sourceTree = "<group>"; };
+		54055F345F8BEC9FC56F1799 /* Pods_ReactNativeBrotherPrinters.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ReactNativeBrotherPrinters.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		BAE0972B8C520D9686166733 /* Pods-ReactNativeBrotherPrinters.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReactNativeBrotherPrinters.debug.xcconfig"; path = "Target Support Files/Pods-ReactNativeBrotherPrinters/Pods-ReactNativeBrotherPrinters.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -34,7 +34,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7C011CA2970839D47FC1D8B3 /* Pods_ReactNativeBrotherPrinters.framework in Frameworks */,
+				18E633BD32B7E837F2ABDEEB /* Pods_ReactNativeBrotherPrinters.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -49,31 +49,31 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		2D23B7F22F69A2CF256B5460 /* Frameworks */ = {
+		58B511D21A9E6C8500147676 = {
 			isa = PBXGroup;
 			children = (
-				49DBED8AC320EBCF00FA637F /* Pods_ReactNativeBrotherPrinters.framework */,
+				134814211AA4EA7D00B7C361 /* Products */,
+				9368BADDEB21EF9A9DFC2557 /* Pods */,
+				E3A501D764ABFD808317E698 /* Frameworks */,
 			);
-			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		3EA18FA211A12397F61CD313 /* Pods */ = {
+		9368BADDEB21EF9A9DFC2557 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				BF810F2AE8820ECD15B335EC /* Pods-ReactNativeBrotherPrinters.debug.xcconfig */,
-				B075CBD3033F9D0F095C16E7 /* Pods-ReactNativeBrotherPrinters.release.xcconfig */,
+				BAE0972B8C520D9686166733 /* Pods-ReactNativeBrotherPrinters.debug.xcconfig */,
+				427543E9A8C65547AA1B6897 /* Pods-ReactNativeBrotherPrinters.release.xcconfig */,
 			);
 			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
-		58B511D21A9E6C8500147676 = {
+		E3A501D764ABFD808317E698 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				134814211AA4EA7D00B7C361 /* Products */,
-				3EA18FA211A12397F61CD313 /* Pods */,
-				2D23B7F22F69A2CF256B5460 /* Frameworks */,
+				54055F345F8BEC9FC56F1799 /* Pods_ReactNativeBrotherPrinters.framework */,
 			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -83,7 +83,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 58B511EF1A9E6C8500147676 /* Build configuration list for PBXNativeTarget "ReactNativeBrotherPrinters" */;
 			buildPhases = (
-				C53BBA62FBD464C75F15BEE5 /* [CP] Check Pods Manifest.lock */,
+				62B14AF806752289A04467DA /* [CP] Check Pods Manifest.lock */,
 				58B511D71A9E6C8500147676 /* Sources */,
 				58B511D81A9E6C8500147676 /* Frameworks */,
 				58B511D91A9E6C8500147676 /* CopyFiles */,
@@ -130,7 +130,7 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		C53BBA62FBD464C75F15BEE5 /* [CP] Check Pods Manifest.lock */ = {
+		62B14AF806752289A04467DA /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -278,7 +278,7 @@
 		};
 		58B511F01A9E6C8500147676 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BF810F2AE8820ECD15B335EC /* Pods-ReactNativeBrotherPrinters.debug.xcconfig */;
+			baseConfigurationReference = BAE0972B8C520D9686166733 /* Pods-ReactNativeBrotherPrinters.debug.xcconfig */;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
@@ -295,7 +295,7 @@
 		};
 		58B511F11A9E6C8500147676 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B075CBD3033F9D0F095C16E7 /* Pods-ReactNativeBrotherPrinters.release.xcconfig */;
+			baseConfigurationReference = 427543E9A8C65547AA1B6897 /* Pods-ReactNativeBrotherPrinters.release.xcconfig */;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@blanton-cloud/react-native-brother-printers",
   "title": "React Native Brother Printers",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A package that allows you to printer with brother printers",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
This pull request includes several updates to the `ReactNativeBrotherPrinters` module, focusing on enhancing printer status retrieval, improving logging, and updating label size constants. The changes span across JavaScript and Objective-C files, as well as project configuration files.

### Enhancements to Printer Status Retrieval and Logging:

* [`index.js`](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R209-R226): Added a new `getPrinterStatus` function to retrieve the status of a printer, including detailed documentation for the function parameters and return value.
* [`ios/ReactNativeBrotherPrinters.m`](diffhunk://#diff-f1d76a16954e82935126cb91b5e8e0d8598f14e6d5d26461030d4de6bb247d1eR289-R383): Implemented the `getPrinterStatus` method in Objective-C, including detailed logging for debugging purposes.

### Logging Improvements:

* [`ios/ReactNativeBrotherPrinters.m`](diffhunk://#diff-f1d76a16954e82935126cb91b5e8e0d8598f14e6d5d26461030d4de6bb247d1eR86-R90): Added extensive logging in the `printImage` method to track the process and potential errors, including the initialization of the channel and printer driver, and the retrieval of printer status. [[1]](diffhunk://#diff-f1d76a16954e82935126cb91b5e8e0d8598f14e6d5d26461030d4de6bb247d1eR86-R90) [[2]](diffhunk://#diff-f1d76a16954e82935126cb91b5e8e0d8598f14e6d5d26461030d4de6bb247d1eR105-R133) [[3]](diffhunk://#diff-f1d76a16954e82935126cb91b5e8e0d8598f14e6d5d26461030d4de6bb247d1eR155-R166) [[4]](diffhunk://#diff-f1d76a16954e82935126cb91b5e8e0d8598f14e6d5d26461030d4de6bb247d1eR181)

### Label Size Constants Update:

* [`index.js`](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L7-R75): Renamed label size constants to follow a more descriptive naming convention and added new label size constants. Updated the `LabelSize` object accordingly.

### Automatic Label Size Determination:

* [`ios/ReactNativeBrotherPrinters.m`](diffhunk://#diff-f1d76a16954e82935126cb91b5e8e0d8598f14e6d5d26461030d4de6bb247d1eR155-R166): Added a method to automatically determine the label size based on media information if not provided in the options. [[1]](diffhunk://#diff-f1d76a16954e82935126cb91b5e8e0d8598f14e6d5d26461030d4de6bb247d1eR155-R166) [[2]](diffhunk://#diff-f1d76a16954e82935126cb91b5e8e0d8598f14e6d5d26461030d4de6bb247d1eR435-R497)

### Project Configuration Updates:

* [`ios/ReactNativeBrotherPrinters.xcodeproj/project.pbxproj`](diffhunk://#diff-19543b86494d1175d0b02c977fc1232ac3ea3f7b7e917236e1fba2f7daf3a0a5L10-R10): Updated references to framework and configuration files to reflect new identifiers. [[1]](diffhunk://#diff-19543b86494d1175d0b02c977fc1232ac3ea3f7b7e917236e1fba2f7daf3a0a5L10-R10) [[2]](diffhunk://#diff-19543b86494d1175d0b02c977fc1232ac3ea3f7b7e917236e1fba2f7daf3a0a5L27-R37) [[3]](diffhunk://#diff-19543b86494d1175d0b02c977fc1232ac3ea3f7b7e917236e1fba2f7daf3a0a5L52-R76) [[4]](diffhunk://#diff-19543b86494d1175d0b02c977fc1232ac3ea3f7b7e917236e1fba2f7daf3a0a5L86-R86)